### PR TITLE
Landing page tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,4 @@ gem 'devise'
 
 gem 'sprockets', '2.11.0'
 
+gem 'factory_girl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       warden (~> 1.2.3)
     erubis (2.7.0)
     execjs (2.6.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
     haml (4.0.7)
       tilt
     hike (1.2.3)
@@ -130,6 +132,7 @@ DEPENDENCIES
   bootstrap-sass (= 3.3.5.1)
   coffee-rails (~> 4.0.0)
   devise
+  factory_girl
   haml
   jbuilder (~> 1.2)
   jquery-rails

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,11 @@ class ActiveSupport::TestCase
   #
   # Note: You'll currently still have to declare fixtures explicitly in integration tests
   # -- they do not yet inherit this setting
-  fixtures :all
+  #fixtures :all
 
   # Add more helper methods to be used by all tests here...
+end
+
+class ActionController::TestCase
+  include Devise::TestHelpers
 end


### PR DESCRIPTION
I disabled fixtures in the test_helper file, added the factory_girl gem, and included test helpers for devise, so the `should get index` test passes and doesn't return an error message.
