### PR TITLE
Amp/issue9 seeds rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ View the wireframes for this app [here](https://github.com/FirehoseCommunity/DEF
 * Matthew Lepley
 * Ken Mazaika
 * Robert Sapunarich
+* Cecelia Havens
+* Amanda Mark

--- a/lib/tasks/sampledata.rake
+++ b/lib/tasks/sampledata.rake
@@ -11,12 +11,10 @@ namespace :users do
 # regardless of explicitly setting the admin param to true. ~AMP
 
   desc 'call "rake users:user[email,password]" to add user'
-  task :user, [:email, :pass] => [:environment, :admin] do |t, args|
+  task :user, [:email, :pass] => :environment do |t, args|
     args.with_defaults(:email => "user@fhpdefcontest.net", :pass => "awesomesauce")
     adduser(args[:email], args[:pass])
   end
-# As it stands the above :user task will invoke the :admin task before it runs.
-# To disable dependency, remove the ":admin" that directly follows ":environment" ~AMP
 
   def addadmin(email, pass)    
     User.create(email: email, password: pass, password_confirmation: pass, admin: true)

--- a/lib/tasks/sampledata.rake
+++ b/lib/tasks/sampledata.rake
@@ -1,0 +1,28 @@
+# sampledata.rake
+
+
+namespace :users do
+  desc 'call "rake users:admin[email,password]" to add admin'
+  task :admin, [:email, :pass] => :environment do |t, args|
+    args.with_defaults(:email => "admin@fhpdefcontest.net", :pass => "awesomesauce")
+    addadmin(args[:email], args[:pass])
+  end
+# Currently only the FIRST user added will become the admin user,
+# regardless of explicitly setting the admin param to true. ~AMP
+
+  desc 'call "rake users:user[email,password]" to add user'
+  task :user, [:email, :pass] => [:environment, :admin] do |t, args|
+    args.with_defaults(:email => "user@fhpdefcontest.net", :pass => "awesomesauce")
+    adduser(args[:email], args[:pass])
+  end
+# As it stands the above :user task will invoke the :admin task before it runs.
+# To disable dependency, remove the ":admin" that directly follows ":environment" ~AMP
+
+  def addadmin(email, pass)    
+    User.create(email: email, password: pass, password_confirmation: pass, admin: true)
+  end
+
+  def adduser(email, pass)    
+    User.create(email: email, password: pass, password_confirmation: pass)
+  end
+end


### PR DESCRIPTION
Updated Readme to show current contributors.

To use this custom Rake task:
"rake users:admin" without params will add a default "admin@fhpdefcontest.net" with password "awesomesauce"
"rake users:admin[youremail,password]" NO SPACES because rake is quirky, will add an explicit admin user with the specified email and password. There is no email format validation here, it's just for seeding the database.
"rake users:user" without params will add a default "user@fhpdefcontest.net" with password "awesomesauce"
"rake users:user[email,password]" will add the explicit user.

CAVEATS:
- DB only allows FIRST user to be admin at this time so A) even running the :admin option as a non-primary user will not currently set them as admin and B) running the :user option first will set them as admin.
- Can pass just an email to have password default to "awesomesauce"

Once other Models are ready for data to be generated I/we can update this sampledata.rake file to add more rake tasks and generate more sample data of different types.  Just wanted to get this user task up quickly. 
