### PR TITLE
Fix the broken comments.

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,7 @@ class Comment < ActiveRecord::Base
   belongs_to :user
   belongs_to :post
   
- 
+  def controlled_by?(user)
+    self.user == user
+  end 
 end

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -33,8 +33,8 @@
     %blockquote
       \#{comment.message}
       %small= comment.user_id
-  // - if comment.controlled_by?(current_user)
-  //   = link_to 'Destroy', comment_path(comment), :method => :delete, :class => 'btn btn-xs btn-primary pull-right'
+      - if comment.controlled_by?(current_user)
+        = link_to 'Destroy', comment_path(comment), :method => :delete, :class => 'btn btn-xs btn-primary pull-right'
   .clr 
     
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Defcon::Application.routes.draw do
   resources :posts do
     resources :comments, :only => :create 
   end 
-  
+  resources :comments, :only => :destroy  
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 


### PR DESCRIPTION
Initially I saw this error message once uncommenting your code:

![screen shot 2015-12-21 at 4 35 53 pm](https://cloud.githubusercontent.com/assets/233615/11941978/55cc6c68-a801-11e5-900c-6abb260df82c.png)

I looked in the comment model, where `controlled_by?` should be defined if we're going to call it in the view.  It wasn't there so I added it.  Then I saw an error message:

```
Undefined method comments_controller_path
```

From there I went into `rake routes` and saw the destroy action wasn't hooked up.  Then when I refreshed the page comment deletion worked.

This pull request is set to go into the `comments` branch.  If you press the merge you can update your feature branch by running:

```
git pull origin comments
```

After clicking the merge button.
