### PR TITLE
Amp/admins promote users issue16

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ View the wireframes for this app [here](https://github.com/FirehoseCommunity/DEF
 * Robert Sapunarich
 * Cecelia Havens
 * Amanda Mark
+* Jeff Gerlach
+
+## Developer notes
+
+To use custom Rake tasks:
+* "rake users:admin" without params will add a default "admin@fhpdefcontest.net" with password "awesomesauce"
+* "rake users:admin[youremail,password]" NO SPACES because rake is quirky, will add an explicit admin user with the specified email and password. There is no email format validation here, it's just for seeding the database.
+* "rake users:user" without params will add a default "user@fhpdefcontest.net" with password "awesomesauce"
+* "rake users:user[email,password]" will add the explicit user.
+* Can pass just an email to have password default to "awesomesauce"
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,19 +6,18 @@ class User < ActiveRecord::Base
 
 
   has_many :posts
-  before_save :check_if_first_user
   has_many :comments 
   validates :name, presence: { :message => "Name is required!" }
   scope :users_to_notify, -> { where(:post_notification => true)  }
 
-  def check_if_first_user
-    self.admin = !User.any?
-    return true
+  def can_edit?(p)
+      return false if p.blank?
+
+      p.user_id == self.id 
   end
 
-def can_edit?(p)
-    return false if p.blank?
+  def promote(user)
+    self.admin ? user.update(:admin => true) : false
+  end
 
-    p.user_id == self.id 
-end
 end 

--- a/db/migrate/20160103070107_add_admin_default_false_to_users.rb
+++ b/db/migrate/20160103070107_add_admin_default_false_to_users.rb
@@ -1,0 +1,8 @@
+class AddAdminDefaultFalseToUsers < ActiveRecord::Migration
+  def up
+    change_column :users, :admin, :boolean, default: false
+  end
+  def down
+    change_column :users, :admin, :boolean, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160101022641) do
+ActiveRecord::Schema.define(version: 20160103070107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 20160101022641) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
-    t.boolean  "admin"
+    t.boolean  "admin",                  default: false
     t.boolean  "post_notification",      default: true
     t.boolean  "comment_notification",   default: true
     t.string   "name",                   default: "I Am Awesome"

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -73,7 +73,6 @@ class UsersControllerTest < ActionController::TestCase
     sign_in p
     put :update, id: u.id, user: { name: "ILovePizza" }
     u.reload
-    waiting for admin flag fix
     assert_equal "ILovePizza", u.name
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -73,9 +73,8 @@ class UsersControllerTest < ActionController::TestCase
     sign_in p
     put :update, id: u.id, user: { name: "ILovePizza" }
     u.reload
-    # waiting for admin flag fix
-    #assert_equal "ILovePizza", u.name
-    assert_redirected_to root_path
+    waiting for admin flag fix
+    assert_equal "ILovePizza", u.name
   end
 
   test "will not allow non-admin to edit user info" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,11 +1,6 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "first user becomes admin" do
-  #   user = User.create(:email => "test1@example.com", :password => "password", :password_confirmation => "password")
-  #   assert user.admin
-  # end
-
   test "admin promotion" do
     user = User.create(:email => "test1@example.com", :password => "password", :password_confirmation => "password")
     user2 = User.create(:email => "test2@example.com", :password => "password", :password_confirmation => "password", :admin => true)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,15 +1,18 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  test "first user becomes admin" do
-    user = User.create(:email => "test1@example.com", :password => "password", :password_confirmation => "password")
-    assert user.admin
-  end
+  # test "first user becomes admin" do
+  #   user = User.create(:email => "test1@example.com", :password => "password", :password_confirmation => "password")
+  #   assert user.admin
+  # end
 
-  test "second user does not become admin" do
+  test "admin promotion" do
     user = User.create(:email => "test1@example.com", :password => "password", :password_confirmation => "password")
-    user2 = User.create(:email => "test2@example.com", :password => "password", :password_confirmation => "password")
-    assert !user2.admin
+    user2 = User.create(:email => "test2@example.com", :password => "password", :password_confirmation => "password", :admin => true)
+    assert !user.admin
+    assert user2.admin
+    user2.promote(user)
+    assert user.admin
   end
 
   test "user won't be added if username blank" do


### PR DESCRIPTION
Addresses Issue https://github.com/FirehoseCommunity/DEFCON/issues/16
This branch cleans up the first-user-is-only-admin problem, it sets the default :admin value of new users to false, it adds the promote(user) method to the User model and it adds some text to the Readme.
