### PR TITLE
Make links clickable in post show and index views using auto_link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,4 @@ gem 'factory_girl_rails'
 
 gem 'simple_form'
 
+gem 'rails_autolink'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.0.1)
       sprockets-rails (~> 2.0.0)
+    rails_autolink (1.1.6)
+      rails (> 3.1)
     railties (4.0.1)
       actionpack (= 4.0.1)
       activesupport (= 4.0.1)
@@ -144,9 +146,13 @@ DEPENDENCIES
   jquery-rails
   pg
   rails (= 4.0.1)
+  rails_autolink
   sass-rails
   sdoc
   simple_form
   sprockets (= 2.11.0)
   turbolinks
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  require 'rails_autolink'
 end

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -25,7 +25,7 @@
 - @posts.each do |post|
   .booyah-box.col-xs-10.col-xs-offset-1
     %h1= link_to post.title, post_path(post)
-    %i= post.body
+    %i= auto_link(post.body, :html => { :target => '_blank' }).html_safe
     %br/
     %br/
     %p= post.created_at

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,6 +1,6 @@
 .col-xs-offset-1.col-xs-10.booyah-box
   %h1= @post.title
-  %i= @post.body
+  %i= auto_link(@post.body, :html => { :target => '_blank' }).html_safe
   %br/
   %br/
  


### PR DESCRIPTION
apparently auto_link was removed and put into it's own gem back in Rails 3, included that and used it on posts index and show (hopefully won't cause problems with the rich text editor adding link tags in manually)
