### PR TITLE
Add a markdown editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,7 @@ gem "opengraph_parser"
 gem "twitter-text"
 
 gem 'fakeweb'
+
+gem 'pagedown-bootstrap-rails'
+
+gem "font-awesome-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     fakeweb (1.3.0)
+    font-awesome-rails (4.5.0.0)
+      railties (>= 3.2, < 5.0)
     haml (4.0.7)
       tilt
     hike (1.2.3)
@@ -81,6 +83,8 @@ GEM
       addressable
       nokogiri
     orm_adapter (0.5.0)
+    pagedown-bootstrap-rails (2.1.2)
+      railties (> 3.1)
     pg (0.18.4)
     polyglot (0.3.5)
     rack (1.5.5)
@@ -155,10 +159,12 @@ DEPENDENCIES
   devise
   factory_girl_rails
   fakeweb
+  font-awesome-rails
   haml
   jbuilder (~> 1.2)
   jquery-rails
   opengraph_parser
+  pagedown-bootstrap-rails
   pg
   rails (= 4.0.1)
   rails_autolink
@@ -169,6 +175,3 @@ DEPENDENCIES
   turbolinks
   twitter-text
   uglifier (>= 1.3.0)
-
-BUNDLED WITH
-   1.10.6

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,8 @@
 //
 //= require jquery
 //= require bootstrap-sprockets
+//= require pagedown_bootstrap
+//= require pagedown_init
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,5 @@
  */
 @import "bootstrap-sprockets";
 @import "bootstrap";
+@import "pagedown_bootstrap";
+@import "font-awesome";

--- a/app/inputs/pagedown_input.rb
+++ b/app/inputs/pagedown_input.rb
@@ -1,0 +1,22 @@
+class PagedownInput < SimpleForm::Inputs::TextInput
+  def input
+    out = "<div id=\"wmd-button-bar-#{attribute_name}\"></div>#{wmd_input}"
+
+    if input_html_options[:preview]
+      out << "<div id=\"wmd-preview-#{attribute_name}\" class=\"wmd-preview\"></div>"
+    end
+
+    out.html_safe
+  end
+
+  private
+
+  def wmd_input
+    @builder.text_area(
+      attribute_name,
+      input_html_options.merge(
+        class: 'wmd-input form-control', id: "wmd-input-#{attribute_name}"
+      )
+    )
+  end
+end

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -17,7 +17,7 @@
       .modal-body
         =simple_form_for @post do |f|
           =f.input :title
-          =f.input :body
+          =f.input :body, as: :pagedown, input_html: { preview: true, rows: 10 }
           %br/
           .modal-footer
             %button.btn.btn-default{"data-dismiss" => "modal", :type => "button", class: 'pull-left'} Close


### PR DESCRIPTION
Add `pagedown-bootstrap-rails` to Gemfile.
Add `font-awesome-rails` to Gemfile so vector icons appear the toolbar.
Create `PagedownInput` for `SimpleForm`.
Update `simple_form_for` `post` to accept `body` input `as: :pagedown`.

PageDown is the markdown editor used on Stack Exchange sites. It also includes a live preview of what the user is typing.
