### PR TITLE
Add gravatar feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,5 @@ gem 'fakeweb'
 gem 'pagedown-bootstrap-rails'
 
 gem "font-awesome-rails"
+
+gem 'gravtastic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     fakeweb (1.3.0)
     font-awesome-rails (4.5.0.0)
       railties (>= 3.2, < 5.0)
+    gravtastic (3.2.6)
     haml (4.0.7)
       tilt
     hike (1.2.3)
@@ -164,6 +165,7 @@ DEPENDENCIES
   factory_girl_rails
   fakeweb
   font-awesome-rails
+  gravtastic
   haml
   jbuilder (~> 1.2)
   jquery-rails
@@ -179,3 +181,6 @@ DEPENDENCIES
   turbolinks
   twitter-text
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -34,3 +34,11 @@ body {
   background: url('/assets/crossword.png');
   font-family: Constantia, "Lucida Bright", Lucidabright, "Lucida Serif", Lucida, "DejaVu Serif", "Bitstream Vera Serif", "Liberation Serif", Georgia, serif;
 }
+
+.post-show-title {
+  margin-top: 25px;
+}
+
+.post-show-poster-name {
+  margin-top: 10px;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  include Gravtastic
+  gravtastic
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :invitable, :database_authenticatable,

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -39,9 +39,13 @@
             %h4= link_to post.og_title, post.og_url
             %p= post.og_description
     %hr
-    %p= post.created_at
-    - if post.user.present?
-      %small= post.user.email
+    .row
+      .col-sm-1.col-xs-12
+        =link_to image_tag(post.user.gravatar_url(default: "retro", size: 50), alt: post.user.name, class: "gravatar pull-left"), user_path(post.user)
+      .col-sm-10.col-xs-12
+        %p= post.created_at
+        - if post.user.present?
+          %small= post.user.email
         
       
 

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,5 +1,12 @@
 .col-xs-offset-1.col-xs-10.booyah-box
-  %h1= @post.title
+  .row
+    .col-sm-2.col-xs-12
+      = link_to image_tag(@post.user.gravatar_url(default: "retro"), alt: @post.user.name, class: "gravatar"), user_path(@post.user)
+      %h5
+        .post-show-poster-name
+          %i= @post.user.name
+    .col-sm-8.col-xs-12.post-show-title
+      %h1= @post.title
   %hr
   %p= auto_link(@post.body, :html => { :target => '_blank' }).html_safe
   %br
@@ -8,7 +15,7 @@
   - if @post.og_title.present?
     %h3 Referenced Link:
     %br
-    = link_to image_tag(@post.og_image), @post.og_url
+    = link_to image_tag(@post.og_image, class: "img-responsive"), @post.og_url
     %br
     %br
     %h4= link_to @post.og_title, @post.og_url

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,8 @@
 %h1.text-center User Dashboard
 .booyah-box.col-xs-10.col-xs-offset-1
-  %h2= selected_user.email
+  %h2
+    = image_tag selected_user.gravatar_url(default: "retro"), alt: selected_user.name, class: "gravatar"
+    = selected_user.email
   %hr
   %h4 Name:&nbsp&nbsp #{selected_user.name}
   %h4 Member Since:&nbsp&nbsp #{selected_user.created_at.strftime("%B %d, %Y")}


### PR DESCRIPTION
Add gravtastic gem. Add gravatar image (or default image if no gravatar account) to post index and show views, along with user dashboard. Allow clicking on gravatar to bring you to the user's dashboard. Minor styling updates.

<img width="1103" alt="screen shot 2016-01-07 at 11 22 30 pm" src="https://cloud.githubusercontent.com/assets/13844570/12191770/b31acd64-b595-11e5-81e6-81f39a73a07c.png">

<img width="1117" alt="screen shot 2016-01-07 at 11 22 49 pm" src="https://cloud.githubusercontent.com/assets/13844570/12191773/b89068c6-b595-11e5-99d7-7c4192f82612.png">

<img width="1128" alt="screen shot 2016-01-07 at 11 23 01 pm" src="https://cloud.githubusercontent.com/assets/13844570/12191775/be574b94-b595-11e5-8d62-2ff4ea8e72fd.png">
