### PR TITLE
Add type ahead search on admin users index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ gem 'pagedown-bootstrap-rails'
 gem "font-awesome-rails"
 
 gem 'gravtastic'
+
+gem 'jquery-ui-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.5)
+      railties (>= 3.2.16)
     json (1.8.3)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -167,6 +169,7 @@ DEPENDENCIES
   haml
   jbuilder (~> 1.2)
   jquery-rails
+  jquery-ui-rails
   opengraph_parser
   pagedown-bootstrap-rails
   pg
@@ -178,3 +181,6 @@ DEPENDENCIES
   sprockets (= 2.11.0)
   twitter-text
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/assets/javascripts/admin/users.js
+++ b/app/assets/javascripts/admin/users.js
@@ -1,0 +1,37 @@
+Users = function() {
+  this._input = $('#users-search-txt');
+  this._initAutocomplete();
+};
+
+Users.prototype = {
+  _initAutocomplete: function() {
+    this._input
+      .autocomplete({
+        source: 'users/',
+        appendTo: '#users-search-results',
+        select: $.proxy(this._select, this)
+      })
+      .autocomplete('instance')._renderItem = $.proxy(this._render, this);
+  },
+
+  _render: function(ul, item) {
+    var markup = [
+      '<span class="img">',
+        '<img src="' + item.image_url + '" />',
+      '</span>',
+      '<span class="email">' + item.email + '</span>',
+      '<span class="name">' + item.name + '</span>',
+      '<span class="added">' + item.created_at + '</span>',
+      '<span class="is-admin"> Admin: ' + item.admin + '</span>'
+    ];
+    return $('<li>')
+      .append(markup.join(''))
+      .appendTo(ul);
+  },
+
+  _select: function(e, ui) {
+    //this._input.val(ui.item.email + ' - ' + ui.item.name);
+    //return false;
+    window.location.href = ui.item.edit_url;
+  }
+};

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery-ui/autocomplete
 //= require bootstrap-sprockets
 //= require pagedown_bootstrap
 //= require pagedown_init

--- a/app/assets/stylesheets/admin/users.css.scss
+++ b/app/assets/stylesheets/admin/users.css.scss
@@ -1,3 +1,94 @@
 // Place all the styles related to the admin/users controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.users-search input {
+  width: 50%;
+  font-size: 1em;
+  padding: .5em 1.3em;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 2em;
+  outline: none;
+}
+
+.users-search input:focus {
+}
+
+.users-search .results .ui-widget-content {
+  background: #fff;
+  font-size: .9em;
+  padding: .5em 0;
+  border-color: #ddd;
+  box-shadow: 0 .1em .2em rgba(187, 187, 187, 0.64);
+  line-height: 1.2;
+  max-height: 20em;
+  overflow: hidden;
+  overflow-y: auto;
+}
+
+.users-search .results .ui-menu-item {
+  font-family: 'Helvetica Neue', Helvetica, sans-serif;
+  padding: .4em .6em .4em 6.2em;
+  position: relative;
+  border: 0;
+  border-left: 5px solid transparent;
+  position: relative;
+  height: 6.5em;
+}
+
+.users-search .results .ui-state-focus {
+  background: #fff;
+  border-left-color: #08c;
+  font-weight: 300;
+}
+
+.users-search .results .ui-menu-item .img {
+  position: absolute;
+  width: 5em;
+  height: 6em;
+  top: .4em;
+  left: .6em;
+  overflow: hidden;
+}
+
+.users-search .results .ui-menu-item .img img {
+  max-width: 100%;
+}
+
+.users-search .results .ui-menu-item .email {
+  display: block;
+  color: #555;
+}
+
+.users-search .results .ui-menu-item .name {
+  display: block;
+  font-size: .8em;
+  text-transform: uppercase;
+  color: #aaa;
+  margin-top: .6em;
+  letter-spacing: 1px;
+}
+
+.users-search .results .ui-menu-item .added {
+  display: block;
+  font-size: .8em;
+  color: #aaa;
+  margin-top: .6em;
+  letter-spacing: 1px;
+}
+
+.users-search .results .ui-menu-item .is-admin {
+  display: block;
+  font-size: .8em;
+  color: #aaa;
+  margin-top: .6em;
+  letter-spacing: 1px;
+}
+
+.users-search .results .ui-state-focus .email,
+.users-search .results .ui-state-focus .name,
+.users-search .results .ui-state-focus .added,
+.users-search .results .ui-state-focus .is-admin, {
+  color: #08c;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
  * You're free to add application-wide styles to this file and they'll appear at the top of the
  * compiled file, but it's generally better to create a new file per style scope.
  *
+ *= require jquery-ui/autocomplete
  *= require_self
  *= require_tree .
  */

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,10 @@
 class Admin::UsersController < AdminController
 
   def index
-    @users = User.all
+    respond_to do |format|
+      format.html { @users = User.all }
+      format.json { @users = User.search(params[:term]) }
+    end
   end
 
   def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,8 @@ class User < ActiveRecord::Base
     self.admin ? user.update(:admin => true) : false
   end
 
+  def self.search(term)
+    # could use ILIKE since we're using postgres to drop downcase
+    where('LOWER(email) LIKE :term OR LOWER(name) LIKE :term', term: "%#{term.downcase}%")
+  end
 end 

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,5 +1,14 @@
 / index.html.haml 20160107 Admin Users Index page ~AMP
+:javascript
+  $(function() {
+    new Users;
+  });
 
+.users-search.text-center
+  %input#users-search-txt{:autofocus => "", :type => "text"}
+    #users-search-results.results
+
+%br
 - @users.each do |u|
   .booyah-box.col-xs-10.col-xs-offset-1
     = link_to u.email, edit_admin_user_path(u)

--- a/app/views/admin/users/index.json.jbuilder
+++ b/app/views/admin/users/index.json.jbuilder
@@ -1,0 +1,13 @@
+json.array!(@users) do |user|
+  json.email        user.email
+  json.name         user.name
+  json.image_url    user.gravatar_url(default: "retro")
+  json.edit_url     edit_admin_user_path(user)
+  json.created_at   "Joined: #{user.created_at.strftime("%B %d, %Y")}"
+  if user.admin?
+    json.admin        "Yes"
+  else
+    json.admin        "No"
+  end
+  json.post_notify  user.post_notification
+end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -36,4 +36,38 @@ class Admin::UsersControllerTest < ActionController::TestCase
     refute user.admin?
     assert_redirected_to root_path
   end
+
+  test "search will return user with valid search term" do
+    admin = FactoryGirl.create(:user, admin: true)
+    user = FactoryGirl.create(:user, name: "Pizza the Hutt")
+    sign_in admin
+    # search for name
+    get :index, term: admin.name, format: :json
+    body = JSON.parse(response.body)
+    # should currently be two users with this factory name
+    assert_equal 1, body.size
+    assert_equal body.first["name"], admin.name
+  end
+
+  test "search will return multiple users that match search term" do
+    admin = FactoryGirl.create(:user, admin: true) #default name Robert
+    user = FactoryGirl.create(:user, name: "Robin Hood")
+    sign_in admin
+    # search for name
+    get :index, term: "Rob", format: :json
+    body = JSON.parse(response.body)
+    # should have two users that match
+    assert_equal 2, body.size
+    assert_match (/Rob/), body.first["name"]
+    assert_match (/Rob/), body.last["name"]
+  end
+
+  test "search will return no users with invalid search term" do
+    admin = FactoryGirl.create(:user, admin: true)
+    user = FactoryGirl.create(:user)
+    sign_in admin
+    # search for bad term
+    get :index, term: "lolCatz", format: :json
+    assert_empty JSON.parse(response.body)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -44,4 +44,16 @@ class UserTest < ActiveSupport::TestCase
     user3 = FactoryGirl.create(:user, post_notification: false)
     assert_equal 2, User.all.users_to_notify.count
   end
+
+  test "will find user when searching" do
+    user = FactoryGirl.create(:user)
+    results = User.search("Rob")
+    assert_equal "Robert Sapunarich", results.first.name
+  end
+
+  test "will not find user when searching for non-existant user name or email" do
+    user = FactoryGirl.create(:user)
+    results = User.search("fail")
+    assert_nil results.first
+  end
 end


### PR DESCRIPTION
Add jquery autocomplete to implement type ahead search on the admin index page. Can click on results in list to go to their admin page. Add user search class method. Add json response in admin user controller. Add tests to cover this feature in the model and controller.

Currently doesn't actually return/list search results on the page (just in a drop-down box that lets you click on results) - in fact hitting enter on the search box doesn't do anything (didn't see that mentioned in issue #56 so I left it out), but shouldn't be hard to add that functionality in if it's wanted. Also added some styling for the search elements so we can change that if desired.

<img width="1347" alt="screen shot 2016-01-09 at 9 57 30 pm" src="https://cloud.githubusercontent.com/assets/13844570/12220077/055c7fe6-b71c-11e5-899d-4edd3ec05f9c.png">

<img width="1245" alt="screen shot 2016-01-09 at 9 57 04 pm" src="https://cloud.githubusercontent.com/assets/13844570/12220080/0bdeb474-b71c-11e5-8d55-f2c1ed061004.png">
