### PR TITLE
Sends a notification when a new post is created

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,7 @@ gem "font-awesome-rails"
 gem 'gravtastic'
 
 gem 'jquery-ui-rails'
+
+group :test, :development do
+  gem 'pry-byebug'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
     builder (3.1.4)
+    byebug (8.2.1)
+    coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -79,6 +81,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile2 (2.0.0)
     minitest (4.7.5)
@@ -93,6 +96,13 @@ GEM
       railties (> 3.1)
     pg (0.18.4)
     polyglot (0.3.5)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -127,6 +137,7 @@ GEM
     simple_form (3.2.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
+    slop (3.6.0)
     sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -173,6 +184,7 @@ DEPENDENCIES
   opengraph_parser
   pagedown-bootstrap-rails
   pg
+  pry-byebug
   rails (= 4.0.1)
   rails_autolink
   sass-rails
@@ -183,4 +195,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,9 +1,10 @@
 class NotificationMailer < ActionMailer::Base
-  default to: Proc.new { User.where(post_notification: true).pluck(:email) },
-          from: "noreply@firehose-defcon.com"
+  default from: "noreply@firehose-defcon.com"
 
-  def send_notification(user)
-    @user = user
-    mail(subject: "A new post from #{@user.email} has been added to the Defcon Student Group")
+  def send_notification(new_post, recipient)
+    @new_post = new_post
+    @recipient = recipient
+    mail(to: @recipient.email,
+         subject: "A new post from #{@new_post.user.email} has been added to the Defcon Student Group")
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,11 +1,9 @@
 class NotificationMailer < ActionMailer::Base
-  default to: Proc.new { User.pluck(:email) },
-    from: "noreply@firehose-defcon.com"
- 
+  default to: Proc.new { User.where(post_notification: true).pluck(:email) },
+          from: "noreply@firehose-defcon.com"
+
   def send_notification(user)
-   @user = user
+    @user = user
     mail(subject: "A new post from #{@user.email} has been added to the Defcon Student Group")
-    
   end
- 
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,8 @@ class Post < ActiveRecord::Base
   belongs_to :user
   has_many :comments
   after_save :parse_og_data_from_first_link # any time we create/update a post, re-grab og data
+  after_create :new_post_notification
+
 
   private
     def parse_og_data_from_first_link
@@ -26,5 +28,9 @@ class Post < ActiveRecord::Base
       # adds http or https to links if they are not present so OG parser works
       return "http://#{url}" unless url[/^https?:\/\//] || url[/^http?:\/\//]
       url
+    end
+
+    def new_post_notification
+      NotificationMailer.send_notification(self.user).deliver
     end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,6 +31,11 @@ class Post < ActiveRecord::Base
     end
 
     def new_post_notification
-      NotificationMailer.send_notification(self.user).deliver
+      @recipients = User.where("post_notification = ? AND email != ?", true, self.user.email)
+      unless @recipients.empty?
+        @recipients.each do |recipient|
+          NotificationMailer.send_notification(self, recipient).deliver
+        end
+      end
     end
 end

--- a/app/views/notification_mailer/send_notification.html.haml
+++ b/app/views/notification_mailer/send_notification.html.haml
@@ -1,5 +1,10 @@
-%p Hey There!
+%p Hey #{@recipient.name}!
 
 %p
-  #{@new_post.user.email}
-  %b shared a post with theFirehoseProject Student Group
+  #{@new_post.user.name}
+  %b shared a post with theFirehoseProject Student Group:
+
+%h2 #{@new_post.title}
+%p= truncate(@new_post.body, length: 100)
+
+=link_to "Continue reading", "#"

--- a/app/views/notification_mailer/send_notification.html.haml
+++ b/app/views/notification_mailer/send_notification.html.haml
@@ -1,6 +1,5 @@
 %p Hey There!
 
 %p
-  #{@user.email}
+  #{@new_post.user.email}
   %b shared a post with theFirehoseProject Student Group
-

--- a/app/views/notification_mailer/send_notification.text.erb
+++ b/app/views/notification_mailer/send_notification.text.erb
@@ -1,5 +1,6 @@
-Hey There!
+Hey #{@recipient.name}!
 
+#{@new_post.user.name} shared a post with theFirehoseProject Student Group:
+#{@new_post.title}.
 
-#{@new_post.user.email}
-shared a post with theFirehoseProject Student Group
+Check it out on Defcon!

--- a/app/views/notification_mailer/send_notification.text.erb
+++ b/app/views/notification_mailer/send_notification.text.erb
@@ -1,6 +1,5 @@
 Hey There!
 
 
-#{@user.email}
+#{@new_post.user.email}
 shared a post with theFirehoseProject Student Group
-

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -11,7 +11,7 @@ class PostsControllerTest < ActionController::TestCase
     u = FactoryGirl.create(:user)
     sign_in u
     get :index
-    assert_response :success      
+    assert_response :success
   end
 
   test "make a post" do
@@ -25,7 +25,7 @@ class PostsControllerTest < ActionController::TestCase
         }
       }
     end
-    assert_redirected_to posts_path      
+    assert_redirected_to posts_path
   end
 
   test "show post page" do
@@ -35,5 +35,13 @@ class PostsControllerTest < ActionController::TestCase
     get :show, id: p.id
     assert_response :success
   end
-  
+
+  test "send new post notification" do
+    assert_difference 'ActionMailer::Base.deliveries.size', +1 do
+      post = FactoryGirl.create(:post)
+    end
+    notification = ActionMailer::Base.deliveries.last
+    assert_match(/A new post/, notification.subject)
+  end
+
 end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -36,12 +36,22 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "send new post notification" do
-    assert_difference 'ActionMailer::Base.deliveries.size', +1 do
+  test "send new post notifications" do
+    assert_difference 'ActionMailer::Base.deliveries.size', +2 do
+      @user1 = FactoryGirl.create(:user)
+      @user2 = FactoryGirl.create(:user)
+      @user3 = FactoryGirl.create(:user, post_notification: false)
       post = FactoryGirl.create(:post)
     end
     notification = ActionMailer::Base.deliveries.last
+    # assert_equal @user.email, notification.to[0]
     assert_match(/A new post/, notification.subject)
   end
 
+  test "notification turned off" do
+    assert_no_difference 'ActionMailer::Base.deliveries.size' do
+      @user = FactoryGirl.create(:user, post_notification: false)
+      post = FactoryGirl.create(:post)
+    end
+  end
 end


### PR DESCRIPTION
Notifications for new posts published are delivered to users with `post_notification: true` with and `after_create` callback in the Post model.

P.S. I added the `pry-byebug` gem for debugging purposes.
