### PR TITLE
show post age

### DIFF
--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -87,3 +87,14 @@ body {
 body {
   color: black;
 }
+
+.posted-time-ago{
+  @media (min-width: 768px) {
+    float: right;
+    padding-top: 15px;
+  }
+  @media (max-width: 768px) {
+    padding-top: 5px;
+    margin-bottom: -10px;
+  }
+}

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -88,7 +88,7 @@ body {
   color: black;
 }
 
-.posted-time-ago{
+.posted-time-ago {
   @media (min-width: 768px) {
     float: right;
     padding-top: 15px;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,6 +5,7 @@
     = stylesheet_link_tag    "application", media: "all"
     = javascript_include_tag "application"
     = csrf_meta_tags
+    %meta{:content => "width=device-width, initial-scale=1", :name => "viewport"}
   %body
     %nav.navbar.navbar-inverse{:role => "navigation"}
       .container-fluid

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -27,13 +27,21 @@
 
 - @posts.each do |post|
   .booyah-box.col-xs-10.col-xs-offset-1
-    %h1= link_to post.title, post_path(post)
+    .row
+      .col-sm-6.col-xs-12
+        %h1= link_to post.title, post_path(post)
+      .col-sm-6.col-xs-12
+        %p.posted-time-ago
+          Posted
+          = time_ago_in_words(post.created_at)
+          ago
     %hr
     .row
-      .col-xs-6
+      .col-sm-6.col-xs-12
         %p=  auto_link(truncate(post.body, length: 250), :html => { :target => '_blank' })
-      .col-xs-6
+      .col-sm-6.col-xs-12
         - if post.og_title.present?
+          %hr.visible-xs
           .col-xs-3
             = link_to image_tag(post.og_image, class: "img-responsive"), post.og_url
           .col-xs-9

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -5,22 +5,29 @@
       %h5
         .post-show-poster-name
           %i= @post.user.name
-    .col-sm-8.col-xs-12.post-show-title
+    .col-sm-6.col-xs-12.post-show-title
       %h1= @post.title
+    .col-sm-4.col-xs-12.posted-time-ago-post-show
+      %p.posted-time-ago
+        Posted
+        = time_ago_in_words(@post.created_at)
+        ago
   %hr
   %p= auto_link(@post.body, :html => { :target => '_blank' }).html_safe
   %br
   %br
   %hr
   - if @post.og_title.present?
-    %h3 Referenced Link:
-    %br
-    = link_to image_tag(@post.og_image, class: "img-responsive"), @post.og_url
-    %br
-    %br
-    %h4= link_to @post.og_title, @post.og_url
-    %p=@post.og_description
-  %br
+    .row
+      .col-xs-12
+        %h3 Referenced Link:
+        %br
+        = link_to image_tag(@post.og_image, class: "img-responsive pull-left"), @post.og_url
+        %br
+      .col-xs-12
+        %br
+        %h4= link_to @post.og_title, @post.og_url
+        %p=@post.og_description
 
 .col-xs-10.col-xs-offset-1
   %h1.pull-left Comments


### PR DESCRIPTION
Should take care of #76. Added the post age using the Rails helper method `time_ago_in_words` (gotta love Rails, eh?) - since it's a default helper, I left out tests (could maybe check for its' presence in integration testing). Added some mobile-friendly formatting/styling, and also added the viewport meta tag to the application HAML.

Post Index page desktop view:
<img width="1095" alt="screen shot 2016-01-11 at 11 31 24 pm" src="https://cloud.githubusercontent.com/assets/13844570/12257259/22a94fb4-b8c2-11e5-934f-1731a4ee35b6.png">

Post Index page mobile view:
<img width="651" alt="screen shot 2016-01-11 at 11 31 08 pm" src="https://cloud.githubusercontent.com/assets/13844570/12257273/35b74e9e-b8c2-11e5-86fd-9c2411ef07a6.png">

Post Show Page (desktop):
<img width="1179" alt="screen shot 2016-01-12 at 12 14 17 am" src="https://cloud.githubusercontent.com/assets/13844570/12257280/43d0a926-b8c2-11e5-936a-87d97663bed9.png">
