### PR TITLE
Put invitations under admin namespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,3 @@ DEPENDENCIES
   sprockets (= 2.11.0)
   twitter-text
   uglifier (>= 1.3.0)
-
-BUNDLED WITH
-   1.11.2

--- a/app/controllers/admin/users/invitations_controller.rb
+++ b/app/controllers/admin/users/invitations_controller.rb
@@ -1,4 +1,4 @@
-class Users::InvitationsController < Devise::InvitationsController
+class Admin::Users::InvitationsController < Devise::InvitationsController
   before_action :check_if_admin
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Defcon::Application.routes.draw do
-  devise_for :users, :skip => :registerable, :controllers => { :invitations => 'users/invitations' } 
+  devise_for :users, :skip => :registerable, :controllers => { :invitations => 'admin/users/invitations' } 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,9 +55,6 @@ ActiveRecord::Schema.define(version: 20160104012421) do
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
     t.boolean  "admin",                  default: false
-    t.boolean  "post_notification",      default: true
-    t.boolean  "comment_notification",   default: true
-    t.string   "name",                   default: "I Am Awesome"
     t.string   "invitation_token"
     t.datetime "invitation_created_at"
     t.datetime "invitation_sent_at"
@@ -66,6 +63,9 @@ ActiveRecord::Schema.define(version: 20160104012421) do
     t.integer  "invited_by_id"
     t.string   "invited_by_type"
     t.integer  "invitations_count",      default: 0
+    t.boolean  "post_notification",      default: true
+    t.boolean  "comment_notification",   default: true
+    t.string   "name",                   default: "I Am Awesome"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/test/controllers/users/invitations_controller_test.rb
+++ b/test/controllers/users/invitations_controller_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Users::InvitationsControllerTest < ActionController::TestCase
+class Admin::Users::InvitationsControllerTest < ActionController::TestCase
   
   def setup
     @request.env["devise.mapping"] = Devise.mappings[:user]
@@ -18,5 +18,12 @@ class Users::InvitationsControllerTest < ActionController::TestCase
     sign_in user
     get :new
     assert_response :unauthorized
+  end
+
+  test "admin can invite user" do
+    admin = User.create(:email => "example@example.com", :password => "password", :password_confirmation => "password", :admin => true)
+    sign_in admin
+    post :create
+    assert_response :success
   end
 end


### PR DESCRIPTION
Don't know if this is ready to merge yet, but I wanted to get something up here. Hey @amarkpark, what do you think of this so far? I noticed that the `verify_admin` method in the `AdminController` is similar to my `check_if_admin` method, but it's private rather than protected, so I couldn't use it in the `InvitationsController` if it inherited from `AdminController`.
