### PR TITLE
Remove white header line from navbar.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,3 @@ DEPENDENCIES
   sprockets (= 2.11.0)
   twitter-text
   uglifier (>= 1.3.0)
-
-BUNDLED WITH
-   1.11.2

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -60,6 +60,7 @@ h1, h2, h3, h4, h5, h6, .navbar {
   font-family: "Helvetica Neue", Helvetica;
   font-weight: 100;
   text-shadow: rgba(0,0,0,0.95) 1px 1px;
+  white-space: normal;
 }
 
 .frosty h2 {
@@ -81,6 +82,7 @@ body {
 
 .btn {
   border-radius:0;
+  white-space: normal;
 }
 
 .add-comment-button {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -43,5 +43,5 @@
       // - else
       //   Hello #{current_user.email}
       //   = link_to  'Sign out', destroy_user_session_path, :method => :delete
-    %hr
+    / %hr
     = yield

--- a/app/views/static_pages/index.html.haml
+++ b/app/views/static_pages/index.html.haml
@@ -3,7 +3,7 @@
   %br/
   %br/
   %br/
-  .frosty.col-xs-5.col-xs-offset-5.text-center
+  .frosty.col-xs-4.col-xs-offset-4.text-center
     %br/
     %h1 Welcome to Defcon
     %br/


### PR DESCRIPTION
Center `frosty` box on landing page.
Set value for `white-space` property to `normal` for `btn` so it's responsive to mobile screens.
Need to make text in `frosty` box responsive so it's responsive on mobile screens.
